### PR TITLE
Change theme_color manifest to #fad0c4

### DIFF
--- a/site.webmanifest
+++ b/site.webmanifest
@@ -14,7 +14,7 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
+    "theme_color": "#fad0c4",
+    "background_color": "#fad0c4",
     "display": "standalone"
 }


### PR DESCRIPTION
Great work @uyouthe!! I got to use sleeep a bunch of times, really cute application. 

I noticed that, when installed it as a pwa on Android, the manifest theme color (especially on the notification) didn't match the background colour of the application. 

As an user of this application I thought that would be more appealing to match these two colours, as it looks like a full application and more continuous and pleasing. (if I may) 

![Sleeep pwa notification bar color #ffffff](https://user-images.githubusercontent.com/22895284/69890713-840eb580-12f7-11ea-8ff7-d2a9a257e833.jpg)
